### PR TITLE
Add env variable for remote user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV LD_LIBRARY_PATH=/opt/shibboleth/lib64:$LD_LIBRARY_PATH
 # Shibd log level
 ENV LOG_LEVEL=INFO
 ENV SHIBD_VERSION=3.0.4-3.2
+ENV SHIBD_REMOTE_USER=somerandomname
 
 WORKDIR /etc/shibboleth
 

--- a/shibboleth2.xml-template
+++ b/shibboleth2.xml-template
@@ -27,7 +27,7 @@
 
    <ApplicationDefaults entityID="${SHIBBOLETH_SP_ENTITY_ID}"
       signing="true" encryption="false"
-      REMOTE_USER="somerandomname">
+      REMOTE_USER="${SHIBD_REMOTE_USER}">
 
       <Sessions lifetime="7200" timeout="3600" relayState="ss:db"
          idpHistory="true" idpHistoryDays="7"


### PR DESCRIPTION
Adds SHIBD_REMOTE_USER env variable for setting remote user value

A default value added to docker file in order to not interfere with existing setups